### PR TITLE
New Feature: keep table tags

### DIFF
--- a/justext/core.py
+++ b/justext/core.py
@@ -20,7 +20,6 @@ from .paragraph import Paragraph
 from ._compat import unicode, ignored
 from .utils import is_blank, get_stoplist, get_stoplists
 
-
 MAX_LINK_DENSITY_DEFAULT = 0.2
 LENGTH_LOW_DEFAULT = 70
 LENGTH_HIGH_DEFAULT = 200
@@ -161,7 +160,7 @@ class ParagraphMaker(ContentHandler):
                 table_element = self.dom.xpath(self.paragraph.xpath)[0]
                 for element in table_element.xpath('//*'):
                     element.attrib.clear()
-                self.paragraph.text = ''.join(tostring(table_element).decode('utf-8').split())
+                self.paragraph.text = re.sub('\s+(?=<)', '', tostring(table_element).decode('utf-8')).strip()
             self.paragraphs.append(self.paragraph)
 
         self.paragraph = Paragraph(self.path)
@@ -241,9 +240,9 @@ class PathInfo(object):
 
 
 def classify_paragraphs(paragraphs, stoplist, length_low=LENGTH_LOW_DEFAULT,
-        length_high=LENGTH_HIGH_DEFAULT, stopwords_low=STOPWORDS_LOW_DEFAULT,
-        stopwords_high=STOPWORDS_HIGH_DEFAULT, max_link_density=MAX_LINK_DENSITY_DEFAULT,
-        no_headings=NO_HEADINGS_DEFAULT):
+                        length_high=LENGTH_HIGH_DEFAULT, stopwords_low=STOPWORDS_LOW_DEFAULT,
+                        stopwords_high=STOPWORDS_HIGH_DEFAULT, max_link_density=MAX_LINK_DENSITY_DEFAULT,
+                        no_headings=NO_HEADINGS_DEFAULT):
     "Context-free paragraph classification."
 
     stoplist = frozenset(w.lower() for w in stoplist)
@@ -340,7 +339,7 @@ def revise_paragraph_classification(paragraphs, max_heading_distance=MAX_HEADING
             new_classes[i] = 'bad'
         # it must be set(['good', 'bad'])
         elif (prev_neighbour == 'bad' and get_prev_neighbour(i, paragraphs, ignore_neargood=False) == 'neargood') or \
-             (next_neighbour == 'bad' and get_next_neighbour(i, paragraphs, ignore_neargood=False) == 'neargood'):
+                (next_neighbour == 'bad' and get_next_neighbour(i, paragraphs, ignore_neargood=False) == 'neargood'):
             new_classes[i] = 'good'
         else:
             new_classes[i] = 'bad'
@@ -374,11 +373,11 @@ def revise_paragraph_classification(paragraphs, max_heading_distance=MAX_HEADING
 
 
 def justext(html_text, stoplist, length_low=LENGTH_LOW_DEFAULT,
-        length_high=LENGTH_HIGH_DEFAULT, stopwords_low=STOPWORDS_LOW_DEFAULT,
-        stopwords_high=STOPWORDS_HIGH_DEFAULT, max_link_density=MAX_LINK_DENSITY_DEFAULT,
-        max_heading_distance=MAX_HEADING_DISTANCE_DEFAULT, no_headings=NO_HEADINGS_DEFAULT,
-        encoding=None, default_encoding=DEFAULT_ENCODING,
-        enc_errors=DEFAULT_ENC_ERRORS, preprocessor=preprocessor, keep_tables_tags=False):
+            length_high=LENGTH_HIGH_DEFAULT, stopwords_low=STOPWORDS_LOW_DEFAULT,
+            stopwords_high=STOPWORDS_HIGH_DEFAULT, max_link_density=MAX_LINK_DENSITY_DEFAULT,
+            max_heading_distance=MAX_HEADING_DISTANCE_DEFAULT, no_headings=NO_HEADINGS_DEFAULT,
+            encoding=None, default_encoding=DEFAULT_ENCODING,
+            enc_errors=DEFAULT_ENC_ERRORS, preprocessor=preprocessor, keep_tables_tags=False):
     """
     Converts an HTML page into a list of classified paragraphs. Each paragraph
     is represented as instance of class ˙˙justext.paragraph.Paragraph˙˙.
@@ -389,7 +388,7 @@ def justext(html_text, stoplist, length_low=LENGTH_LOW_DEFAULT,
     paragraphs = ParagraphMaker.make_paragraphs(dom, keep_tables_tags=keep_tables_tags)
 
     classify_paragraphs(paragraphs, stoplist, length_low, length_high,
-        stopwords_low, stopwords_high, max_link_density, no_headings)
+                        stopwords_low, stopwords_high, max_link_density, no_headings)
     revise_paragraph_classification(paragraphs, max_heading_distance)
 
     return paragraphs

--- a/justext/core.py
+++ b/justext/core.py
@@ -169,8 +169,6 @@ class ParagraphMaker(ContentHandler):
                 # not be included in the number of tags within the
                 # paragraph
                 self.paragraph.tags_count -= 1
-            elif name == 'table':
-                print('table')
             self._start_new_pragraph()
         else:
             self.br = bool(name == "br")

--- a/justext/core.py
+++ b/justext/core.py
@@ -36,6 +36,12 @@ PARAGRAPH_TAGS = [
     'p', 'pre', 'table', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr',
     'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
 ]
+PARAGRAPH_TAGS_KEEP_TABLES = [
+    'body', 'blockquote', 'caption', 'center', 'col', 'colgroup', 'dd',
+    'div', 'dl', 'dt', 'fieldset', 'form', 'legend', 'optgroup', 'option',
+    'p', 'pre', 'table', 'textarea', 'tfoot', 'thead',
+    'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+]
 DEFAULT_ENCODING = 'utf8'
 DEFAULT_ENC_ERRORS = 'replace'
 CHARSET_META_TAG_PATTERN = re.compile(br"""<meta[^>]+charset=["']?([^'"/>\s]+)""", re.IGNORECASE)
@@ -136,9 +142,7 @@ class ParagraphMaker(ContentHandler):
         cls.keep_tables_tags = keep_tables_tags
         cls.paragraph_tags = PARAGRAPH_TAGS
         if cls.keep_tables_tags:
-            cls.paragraph_tags.remove('tr')
-            cls.paragraph_tags.remove('td')
-            cls.paragraph_tags.remove('th')
+            cls.paragraph_tags = PARAGRAPH_TAGS_KEEP_TABLES
         handler = cls()
         lxml.sax.saxify(root, handler)
         return handler.paragraphs

--- a/justext/core.py
+++ b/justext/core.py
@@ -35,12 +35,6 @@ PARAGRAPH_TAGS = [
     'p', 'pre', 'table', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr',
     'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
 ]
-PARAGRAPH_TAGS_KEEP_TABLES = [
-    'body', 'blockquote', 'caption', 'center', 'col', 'colgroup', 'dd',
-    'div', 'dl', 'dt', 'fieldset', 'form', 'legend', 'optgroup', 'option',
-    'p', 'pre', 'table', 'textarea', 'tfoot', 'thead',
-    'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-]
 DEFAULT_ENCODING = 'utf8'
 DEFAULT_ENC_ERRORS = 'replace'
 CHARSET_META_TAG_PATTERN = re.compile(br"""<meta[^>]+charset=["']?([^'"/>\s]+)""", re.IGNORECASE)
@@ -140,8 +134,6 @@ class ParagraphMaker(ContentHandler):
         cls.dom = root
         cls.keep_tables_tags = keep_tables_tags
         cls.paragraph_tags = PARAGRAPH_TAGS
-        if cls.keep_tables_tags:
-            cls.paragraph_tags = PARAGRAPH_TAGS_KEEP_TABLES
         handler = cls()
         lxml.sax.saxify(root, handler)
         return handler.paragraphs
@@ -175,6 +167,8 @@ class ParagraphMaker(ContentHandler):
                 # not be included in the number of tags within the
                 # paragraph
                 self.paragraph.tags_count -= 1
+            if name == "table" and self.keep_tables_tags:
+                self.paragraph_tags = ["table"]
             self._start_new_pragraph()
         else:
             self.br = bool(name == "br")
@@ -187,6 +181,8 @@ class ParagraphMaker(ContentHandler):
         self.path.pop()
 
         if name in self.paragraph_tags:
+            if name == "table" and self.keep_tables_tags:
+                self.paragraph_tags = PARAGRAPH_TAGS
             self._start_new_pragraph()
         if name == 'a':
             self.link = False

--- a/justext/core.py
+++ b/justext/core.py
@@ -158,7 +158,10 @@ class ParagraphMaker(ContentHandler):
     def _start_new_pragraph(self):
         if self.paragraph and self.paragraph.contains_text():
             if self.keep_tables_tags and self.paragraph.dom_path.endswith('table'):
-                self.paragraph.text = ''.join(tostring(self.dom.xpath(self.paragraph.xpath)[0]).decode('utf-8').split())
+                table_element = self.dom.xpath(self.paragraph.xpath)[0]
+                for element in table_element.xpath('//*'):
+                    element.attrib.clear()
+                self.paragraph.text = ''.join(tostring(table_element).decode('utf-8').split())
             self.paragraphs.append(self.paragraph)
 
         self.paragraph = Paragraph(self.path)

--- a/justext/paragraph.py
+++ b/justext/paragraph.py
@@ -16,6 +16,7 @@ class Paragraph(object):
         self.text_nodes = []
         self.chars_count_in_links = 0
         self.tags_count = 0
+        self._text = None
 
     @property
     def is_heading(self):
@@ -27,6 +28,8 @@ class Paragraph(object):
 
     @property
     def text(self):
+        if self._text:
+            return self._text
         text = "".join(self.text_nodes)
         return normalize_whitespace(text.strip())
 
@@ -67,3 +70,7 @@ class Paragraph(object):
             return 0
 
         return self.chars_count_in_links / text_length
+
+    @text.setter
+    def text(self, text):
+        self._text = text

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag = false
 
 [bumpversion:file:justext/__init__.py]
 
-[pytest]
+[tool:pytest]
 addopts = --quiet --tb=short --color=yes --cov=justext --cov-report=term-missing --no-cov-on-fail
 
 [bdist_wheel]

--- a/tests/test_dom_utils.py
+++ b/tests/test_dom_utils.py
@@ -157,7 +157,7 @@ def test_lxml_do_not_hold_context_from_previous_parsing():
     """
     html_to_dom("<justext></justext>")
 
-    with pytest.raises(lxml.etree.XMLSyntaxError) as e:
+    with pytest.raises(lxml.etree.ParserError) as e:
         html_to_dom("")
 
     assert "justext" not in str(e.value)

--- a/tests/test_sax.py
+++ b/tests/test_sax.py
@@ -313,7 +313,7 @@ class TestSax(unittest.TestCase):
             '  <p>c</p>'
             '  <table>'
             '     <tr>'
-            '        <th>a</th>'
+            '        <th>a b</th>'
             '        <th>b</th>'
             '     </tr>'
             '     <tr>'
@@ -342,8 +342,8 @@ class TestSax(unittest.TestCase):
 
         self.assert_paragraphs_equal(
             paragraphs[1],
-            text="<table><tr><th>a</th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>",
-            words_count=1,
+            text="<table><tr><th>a b</th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>",
+            words_count=2,
             tags_count=6
         )
 

--- a/tests/test_sax.py
+++ b/tests/test_sax.py
@@ -377,7 +377,7 @@ class TestSax(unittest.TestCase):
         assert html_string == returned
 
         paragraphs = ParagraphMaker.make_paragraphs(dom, keep_tables_tags=True)
-        #assert len(paragraphs) == 3
+        assert len(paragraphs) == 3
 
         self.assert_paragraphs_equal(
             paragraphs[0],
@@ -391,6 +391,53 @@ class TestSax(unittest.TestCase):
             text="<table><tr><th><p>a b</p></th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>",
             words_count=2,
             tags_count=7
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[2],
+            text="d",
+            words_count=1,
+            tags_count=0
+        )
+
+    def test_keep_nested_tables(self):
+        html_string = (
+            '<html><body>'
+            '  <p>c</p>'
+            '  <table>'
+            '     <tr>'
+            '        <th><table><th><p>a b</p></th></table></th>'
+            '        <th>b</th>'
+            '     </tr>'
+            '     <tr>'
+            '        <td>1</td>'
+            '        <td>2</td>'
+            '     </tr>'
+            '  </table>  '
+            '  <p>d</p>'
+            '</body></html>'
+        )
+        dom = html.fromstring(html_string)
+
+        returned = html.tostring(dom).decode("utf8")
+        assert html_string == returned
+
+        paragraphs = ParagraphMaker.make_paragraphs(dom, keep_tables_tags=True)
+        assert len(paragraphs) == 3
+
+        self.assert_paragraphs_equal(
+            paragraphs[0],
+            text="c",
+            words_count=1,
+            tags_count=0
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[1],
+            text="<table><tr><th><table><th><p>a b</p></th></table>"
+                 "</th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>",
+            words_count=2,
+            tags_count=8
         )
 
         self.assert_paragraphs_equal(

--- a/tests/test_sax.py
+++ b/tests/test_sax.py
@@ -306,3 +306,50 @@ class TestSax(unittest.TestCase):
             words_count=1,
             tags_count=0
         )
+
+    def test_run_keep_table_twice(self):
+        html_string = (
+            '<html><body>'
+            '  <p>c</p>'
+            '  <table>'
+            '     <tr>'
+            '        <th>a</th>'
+            '        <th>b</th>'
+            '     </tr>'
+            '     <tr>'
+            '        <td>1</td>'
+            '        <td>2</td>'
+            '     </tr>'
+            '  </table>  '
+            '  <p>d</p>'
+            '</body></html>'
+        )
+        dom = html.fromstring(html_string)
+
+        returned = html.tostring(dom).decode("utf8")
+        assert html_string == returned
+
+        paragraphs = ParagraphMaker.make_paragraphs(dom, keep_tables_tags=True)
+        paragraphs = ParagraphMaker.make_paragraphs(dom, keep_tables_tags=True)
+        assert len(paragraphs) == 3
+
+        self.assert_paragraphs_equal(
+            paragraphs[0],
+            text="c",
+            words_count=1,
+            tags_count=0
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[1],
+            text="<table><tr><th>a</th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>",
+            words_count=1,
+            tags_count=6
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[2],
+            text="d",
+            words_count=1,
+            tags_count=0
+        )

--- a/tests/test_sax.py
+++ b/tests/test_sax.py
@@ -214,3 +214,95 @@ class TestSax(unittest.TestCase):
             tags_count=0,
             text="I am inline\nand I am happy"
         )
+
+    def test_keep_table(self):
+        html_string = (
+            '<html><body>'
+            '  <p>c</p>'
+            '  <table>'
+            '     <tr>'
+            '        <th>a</th>'
+            '        <th>b</th>'
+            '     </tr>'
+            '     <tr>'
+            '        <td>1</td>'
+            '        <td>2</td>'
+            '     </tr>'
+            '  </table>  '
+            '  <p>d</p>'
+            '</body></html>'
+        )
+        dom = html.fromstring(html_string)
+
+        returned = html.tostring(dom).decode("utf8")
+        assert html_string == returned
+
+        paragraphs = ParagraphMaker.make_paragraphs(dom, keep_tables_tags=True)
+        assert len(paragraphs) == 3
+
+        self.assert_paragraphs_equal(
+            paragraphs[0],
+            text="c",
+            words_count=1,
+            tags_count=0
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[1],
+            text="<table><tr><th>a</th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>",
+            words_count=1,
+            tags_count=6
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[2],
+            text="d",
+            words_count=1,
+            tags_count=0
+        )
+
+    def test_do_not_keep_table(self):
+        html_string = (
+            '<html><body>'
+            '  <p>c</p>'
+            '  <table>'
+            '     <tr>'
+            '        <th>a</th>'
+            '        <th>b</th>'
+            '     </tr>'
+            '     <tr>'
+            '        <td>1</td>'
+            '        <td>2</td>'
+            '     </tr>'
+            '  </table>  '
+            '  <p>d</p>'
+            '</body></html>'
+        )
+        dom = html.fromstring(html_string)
+
+        returned = html.tostring(dom).decode("utf8")
+        assert html_string == returned
+
+        paragraphs = ParagraphMaker.make_paragraphs(dom)
+        assert len(paragraphs) == 6
+
+        self.assert_paragraphs_equal(
+            paragraphs[0],
+            text="c",
+            words_count=1,
+            tags_count=0
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[1],
+            text="a",
+            words_count=1,
+            tags_count=0
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[5],
+            text="d",
+            words_count=1,
+            tags_count=0
+        )

--- a/tests/test_sax.py
+++ b/tests/test_sax.py
@@ -265,9 +265,9 @@ class TestSax(unittest.TestCase):
         html_string = (
             '<html><body>'
             '  <p>c</p>'
-            '  <table>'
-            '     <tr>'
-            '        <th>a</th>'
+            '  <table width="200px">'
+            '     <tr width="200px">'
+            '        <th width="200px">a</th>'
             '        <th>b</th>'
             '     </tr>'
             '     <tr>'

--- a/tests/test_sax.py
+++ b/tests/test_sax.py
@@ -353,3 +353,49 @@ class TestSax(unittest.TestCase):
             words_count=1,
             tags_count=0
         )
+
+    def test_keep_table_with_p(self):
+        html_string = (
+            '<html><body>'
+            '  <p>c</p>'
+            '  <table>'
+            '     <tr>'
+            '        <th><p>a b</p></th>'
+            '        <th>b</th>'
+            '     </tr>'
+            '     <tr>'
+            '        <td>1</td>'
+            '        <td>2</td>'
+            '     </tr>'
+            '  </table>  '
+            '  <p>d</p>'
+            '</body></html>'
+        )
+        dom = html.fromstring(html_string)
+
+        returned = html.tostring(dom).decode("utf8")
+        assert html_string == returned
+
+        paragraphs = ParagraphMaker.make_paragraphs(dom, keep_tables_tags=True)
+        #assert len(paragraphs) == 3
+
+        self.assert_paragraphs_equal(
+            paragraphs[0],
+            text="c",
+            words_count=1,
+            tags_count=0
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[1],
+            text="<table><tr><th><p>a b</p></th><th>b</th></tr><tr><td>1</td><td>2</td></tr></table>",
+            words_count=2,
+            tags_count=7
+        )
+
+        self.assert_paragraphs_equal(
+            paragraphs[2],
+            text="d",
+            words_count=1,
+            tags_count=0
+        )


### PR DESCRIPTION
Happened to me that while I need to get text from html documents I also need to preserve tables tags, so that I can parse them later on.

Added a boolean parameter to justext() function to keep table tags.

If you think this might be usefull for the community consider to merge the pull request.