### PR TITLE
Handle urllib imports in Python 2 and 3 correctly

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,8 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        # https://dev.to/misobelica/python-features-by-version-3318
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/justext/_compat.py
+++ b/justext/_compat.py
@@ -18,12 +18,12 @@ else:
 string_types = (bytes, unicode,)
 
 
-try:
-    import urllib2 as urllib
-    URLError = urllib.URLError
-except ImportError:
+if PY3:
     import urllib.request as urllib
     from urllib.error import URLError
+else:
+    import urllib2 as urllib
+    URLError = urllib.URLError
 
 
 try:


### PR DESCRIPTION
Fixes #49 where some old library installs urllib2 package even in Python 3 environment.